### PR TITLE
Tweaks and minor improvements

### DIFF
--- a/split-by.rkt
+++ b/split-by.rkt
@@ -1,18 +1,30 @@
-#lang racket
+#lang racket/base
+
 (provide split-by)
+
+(require racket/list)
+
 (define (split-by l f)
   (if (null? l)
       null
-      (let loop ([groups null] [acc (list (car l))] [l (cdr l)] [val (f (car l))])
+      (let loop ([groups null] [acc (list (first l))] [l (rest l)] [val (f (first l))])
         (cond
           [(null? l) (reverse (cons acc groups))]
           [else
-           (define c (car l))
+           (define c (first l))
            (define v (f c))
            (if (equal? val v)
-               (loop groups (cons c acc) (cdr l) val)
-               (loop (cons (reverse acc) groups) (list c) (cdr l) v))]))))
+               (loop groups (cons c acc) (rest l) val)
+               (loop (cons (reverse acc) groups) (list c) (rest l) v))]))))
+
 (module+ test
   (require rackunit)
-  (check-equal? (split-by (range 1.0 5.1 .5) floor)
-                '((1.0 1.5) (2.0 2.5) (3.0 3.5) (4.0 4.5) (5.0))))
+
+  (define (should-never-be-called)
+    (error "was called, shouldn't have been"))
+
+  (check-equal? (split-by '() should-never-be-called)
+                '())
+
+  (check-equal? (split-by '(1.0 1.5 2.0 2.5 3.0) floor)
+                '((1.0 1.5) (2.0 2.5) (3.0))))

--- a/split-by.rkt
+++ b/split-by.rkt
@@ -16,7 +16,9 @@
 (define (split-by l f)
   (if (null? l)
       null
-      (let-values ([(first-split rest-vs) (split-by-once l f (f (first l)))])
+      (let*-values ([(split-val) (f (first l))]
+                    [(first-split rest-vs)
+                     (splitf-at l (lambda (v) (equal? (f v) split-val)))])
         (cons first-split (split-by rest-vs f)))))
 
 (module+ test
@@ -26,15 +28,3 @@
 
   (check-equal? (split-by '(1.0 1.5 2.0 2.5 3.0) floor)
                 '((1.0 1.5) (2.0 2.5) (3.0))))
-
-
-(define (split-by-once vs f split-val)
-  (define (should-include-in-split? v)
-    (equal? (f v) split-val))
-  (splitf-at vs should-include-in-split?))
-
-(module+ test
-  (define-values (split rest-vs)
-    (split-by-once '(1.0 1.5 2.0 2.5 3.0) floor 1.0))
-  (check-equal? split '(1.0 1.5))
-  (check-equal? rest-vs '(2.0 2.5 3.0)))

--- a/split-by.rkt
+++ b/split-by.rkt
@@ -1,6 +1,10 @@
 #lang racket/base
 
-(provide split-by)
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [split-by (-> list? (-> any/c any/c) (listof list?))]))
 
 (require racket/list)
 


### PR DESCRIPTION
This PR makes a handful of small changes:
- Adds a contract `(-> list? (-> any/c any/c) (listof list?))`
- Changes `#lang` from `racket` to `racket/base`
- Adds a test case for empty input
- Splits the recursive buildup and the single step into separate functions for readability. Note - as part of this, the function is now _not_ tail recursive. I don't think this costs any space computationally speaking, since the amount of state that needed to be passed between calls was linear in the size of the input list as opposed to an accumulator in a function like `max`.
- Use `first` and `rest` instead of `car` and `cdr` (this was a stylistic change on my part - I find it far easier to read those names than the historic pair accessors)
